### PR TITLE
ci: fix release workflow artifact upload to immutable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,20 +96,24 @@ jobs:
       run: |
         # Get the most recent draft release
         DRAFT_TAG=$(gh api repos/${{ github.repository }}/releases --jq '[.[] | select(.draft == true)] | first | .tag_name')
-        
+
         if [ -z "$DRAFT_TAG" ] || [ "$DRAFT_TAG" = "null" ]; then
           echo "::error::No draft release found"
           exit 1
         fi
-        
-        # Update draft with correct tag and publish it
+
+        # First, update the draft with the correct tag but keep it as draft
         gh release edit "$DRAFT_TAG" \
           --tag "v${{ needs.version.outputs.versionTag }}" \
           --title "v${{ needs.version.outputs.versionTag }}" \
+          --draft=true
+
+        # Upload built artifacts to the draft release
+        gh release upload "v${{ needs.version.outputs.versionTag }}" dist/* --clobber
+
+        # Finally, publish the release (making it immutable)
+        gh release edit "v${{ needs.version.outputs.versionTag }}" \
           --draft=false \
           --latest
-        
-        # Upload built artifacts to the release
-        gh release upload "v${{ needs.version.outputs.versionTag }}" dist/* --clobber
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Fix Release Workflow Artifact Upload Issue

### Problem
The v0.2.0 release workflow succeeded in publishing to PyPI but failed with HTTP 422 error when uploading artifacts because the release had already been published (making it immutable).

### Error
```
HTTP 422: Cannot upload assets to an immutable release
```

### Solution
Reordered the release workflow steps:

**Before (incorrect order):**
1. Publish release (makes it immutable)
2. ❌ Upload artifacts (fails - release is immutable)

**After (correct order):**
1. Update draft with correct tag (keep as draft)
2. ✅ Upload artifacts to draft release
3. Publish release as final step

### Testing
Ready for the next release to verify the fix works correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>